### PR TITLE
Field type link

### DIFF
--- a/src/Frontend/assets/js/taco-wordpress.js
+++ b/src/Frontend/assets/js/taco-wordpress.js
@@ -102,6 +102,18 @@ TacoWordPress.FieldLinks.FieldLink.prototype = {
     return '<p class="description"></p>';
   },
 
+  getEscaped: function(str) {
+    return str
+      .replace(/[\\]/g, '\\\\')
+      .replace(/[\"]/g, '\\\"')
+      .replace(/[\/]/g, '\\/')
+      .replace(/[\b]/g, '\\b')
+      .replace(/[\f]/g, '\\f')
+      .replace(/[\n]/g, '\\n')
+      .replace(/[\r]/g, '\\r')
+      .replace(/[\t]/g, '\\t');
+  },
+
   initEvents: function() {
     var self = this;
     var $object = this.$object;
@@ -144,8 +156,13 @@ TacoWordPress.FieldLinks.FieldLink.prototype = {
     
     $('body').on('click', '#wp-link-submit', function(event) {
       var linkAtts = self.static_self.wpLink.getAttrs();
-      self.static_self.$last_textfield.parent().find('.actual-value')
-        .val(encodeURIComponent(JSON.stringify(linkAtts)));
+      
+      json_string = encodeURIComponent(
+        self.getEscaped(JSON.stringify(linkAtts))
+      );
+
+      self.static_self.$last_textfield
+        .parent().find('.actual-value').val(json_string);
       
       self.static_self.$last_textfield.val(linkAtts.href);
       

--- a/src/Frontend/assets/js/taco-wordpress.js
+++ b/src/Frontend/assets/js/taco-wordpress.js
@@ -1,0 +1,204 @@
+var TacoWordPress = TacoWordPress || {};
+
+TacoWordPress.FieldLinks = {
+  instances: [],
+  $last_textfield: null,
+  prev_title_text: null,
+  wpActiveEditor: null,
+  wpLink: null
+};
+
+TacoWordPress.FieldLinks.FieldLink = function($object) {
+  this.init($object);
+  TacoWordPress.FieldLinks.instances.push(this);
+  this.instance_id = new Date().getTime(); // for debugging
+};
+
+TacoWordPress.FieldLinks.FieldLink.prototype = {
+  static_self: TacoWordPress.FieldLinks,
+  instance_id: null,
+  href: null,
+  title: null,
+  $object: null,
+
+  init: function($object) {
+    this.$object = $object;
+    this.static_self.wpActiveEditor = window.wpActiveEditor || null;
+    this.static_self.wpLink = window.wpLink;
+    var $ = window.jQuery || window.$;
+
+    if($object.val().search(/\{/) > -1) {
+      var link_object = JSON.parse($object.val());
+      this.href = link_object.href;
+      this.title = link_object.title;
+    }
+
+    $object.css('width', '60%');
+    $object.prop('readonly', true);
+
+    $object.parent().append([
+      this.getAddButtonTemplate(),
+      this.getRemoveButtonTemplate() + ' ',
+      this.getEditButtonTemplate() + ' ',
+      this.getActualValueInputTemplate(
+        this.href, $object.val(), $object.attr('name')
+      ),
+      this.getDescriptionTemplate()
+    ].join(''));
+    
+    $object.attr('name', $object.attr('name') + '_old');
+
+    $object.val((this.href) ? this.href : '');
+    
+    if(this.title) {
+      $object.parent().find('.description')
+        .html([
+          '<b>link text:</b> <span class="link-text">"',
+          this.title, '"</span>'
+        ].join(''));
+
+      $object.parent().find('.btn-remove').show();
+      $object.parent().find('.btn-add').hide();
+    } else {
+      $object.parent().find('.btn-remove').hide();
+      $object.parent().find('.btn-edit').hide();
+    }
+    this.static_self.prev_title_text = $('#link-title-field')
+      .prev('span').text();
+
+    this.initEvents();
+  },
+
+  getAddButtonTemplate: function() {
+    return [
+      '<button class="btn-add button button-secondary">',
+      'Add Link</button>'
+    ].join('');
+  },
+
+  getRemoveButtonTemplate: function() {
+    return [
+      '<button class="btn-remove button button-secondary">',
+      'Remove Link</button>'
+    ].join('');
+  },
+
+  getEditButtonTemplate: function() {
+    return [
+      '<button class="btn-edit button button-secondary">',
+      'Edit Link</button>'
+    ].join('');
+  },
+
+  getActualValueInputTemplate: function(href, val, name) {
+    return [
+      '<input value="', ((href) ? encodeURIComponent(val) : ''),
+      '" type="hidden" class="actual-value" name="', name, '">'
+    ].join('');
+
+  },
+
+  getDescriptionTemplate: function() {
+    return '<p class="description"></p>';
+  },
+
+  initEvents: function() {
+    var self = this;
+    var $object = this.$object;
+    var static_self = this.static_self;
+    var $ = window.jQuery || window.$;
+
+    this.$object.parent().find('.btn-add').on('click', function(e) {
+      e.preventDefault();
+      static_self.wpActiveEditor = true;
+      static_self.wpLink.open();
+      $('#link-title-field').prev('span').text('Body');
+      self.static_self.$last_textfield = $object;
+      return false;
+    });
+
+    this.$object.parent().find('.btn-edit').on('click', function(e) {
+      e.preventDefault();
+      static_self.wpActiveEditor = true;
+      static_self.wpLink.open();
+      $('#url-field').val($object.val());
+      $('#wp-link-submit').val('Update');
+      self.static_self.$last_textfield = $object;
+      
+      var link_text = $object.siblings('.description')
+      .find('.link-text').text()
+      .replace(/^\"|\"$/g, '');
+
+      $('#link-title-field').val((link_text));
+    });
+
+    this.$object.parent().find('.btn-remove').on('click', function(e) {
+      $object.parent().find('.btn-add').show();
+      e.preventDefault();
+      $object.val('');
+      $(this).hide();
+      $object.parent().find('.btn-edit').hide();
+      $object.parent().find('.actual-value').val('');
+      $object.parent().find('.description').text('');
+    });
+    
+    $('body').on('click', '#wp-link-submit', function(event) {
+      console.log(self);
+      var linkAtts = self.static_self.wpLink.getAttrs();
+      self.static_self.$last_textfield.parent().find('.actual-value')
+        .val(encodeURIComponent(JSON.stringify(linkAtts)));
+      
+      self.static_self.$last_textfield.val(linkAtts.href);
+      
+      static_self.wpLink.textarea = $('body');
+      static_self.wpLink.close();
+
+      self.static_self.$last_textfield.parent()
+        .find('.btn-remove').show();
+      
+      self.static_self.$last_textfield.parent()
+        .find('.btn-add').hide();
+      
+      self.static_self.$last_textfield.parent()
+        .find('.btn-edit').show();
+
+      self.static_self.$last_textfield.parent()
+        .find('.description')
+        .html([
+          '<b>link text:</b> <span class="link-text">"',
+          linkAtts.title,
+          '"</span>'
+          ].join(''));
+
+      if(event.preventDefault) {
+        event.preventDefault();
+      } else {
+        event.returnValue = false;
+      }
+      event.stopPropagation();
+    });
+
+    $('body').on('click', '#wp-link-cancel, #wp-link-close', function(event) {
+      $('#link-title-field').prev('span')
+        .text(static_self.prev_title_text);
+
+      static_self.wpLink.textarea = $('body');
+      static_self.wpLink.close();
+
+      if(event.preventDefault) {
+        event.preventDefault();
+      } else {
+        event.returnValue = false;
+      }
+      event.stopPropagation();
+      return false;
+    });
+
+  }
+};
+
+(function($) {
+  $('input[type="link"]').each(function() {
+    new TacoWordPress.FieldLinks.FieldLink($(this));
+  });
+})(jQuery);

--- a/src/Frontend/assets/js/taco-wordpress.js
+++ b/src/Frontend/assets/js/taco-wordpress.js
@@ -143,7 +143,6 @@ TacoWordPress.FieldLinks.FieldLink.prototype = {
     });
     
     $('body').on('click', '#wp-link-submit', function(event) {
-      console.log(self);
       var linkAtts = self.static_self.wpLink.getAttrs();
       self.static_self.$last_textfield.parent().find('.actual-value')
         .val(encodeURIComponent(JSON.stringify(linkAtts)));

--- a/src/Frontend/assets/js/taco-wordpress.js
+++ b/src/Frontend/assets/js/taco-wordpress.js
@@ -129,7 +129,7 @@ TacoWordPress.FieldLinks.FieldLink.prototype = {
       .find('.link-text').text()
       .replace(/^\"|\"$/g, '');
 
-      $('#link-title-field').val((link_text));
+      $('#link-title-field').val(link_text);
     });
 
     this.$object.parent().find('.btn-remove').on('click', function(e) {

--- a/src/Post.php
+++ b/src/Post.php
@@ -1756,6 +1756,17 @@ class Post extends Base
 
 
     /**
+     * Get a decoded object from an encoded string by field name
+     * @param string $field
+     * @return array
+     */
+    public function getDecodedLinkObjectFromField($field)
+    {
+        return json_decode(urldecode($this->get($field)));
+    }
+
+
+    /**
      * Get just the URL from a field type of link
      * @param string $field
      * @return string
@@ -1768,7 +1779,7 @@ class Post extends Base
 
 
     /**
-     * Get a field from a link object (href | title | target)
+     * Get a field from a link object (href | title or body | target)
      * @param string $field
      * @param string $part
      * @return string
@@ -1776,6 +1787,9 @@ class Post extends Base
     public function getLinkPart($field, $part)
     {
         $link_attr = self::decodeLinkObject($this->get($field));
+        if ($part === 'body') {
+            $part = 'title';
+        }
         return $link_attr->$part;
     }
 
@@ -1793,9 +1807,9 @@ class Post extends Base
     public function linkAttribsToHTMLString($link_attr, $body='', $classes='', $id='', $styles='')
     {
         $link_text = null;
-        if(strlen($link_attr->title)) {
+        if (strlen($link_attr->title)) {
             $link_text = $link_attr->title;
-        } elseif(strlen($body)) {
+        } elseif (strlen($body)) {
             $link_text = $body;
         } else {
             $link_text = $link_attr->href;
@@ -1804,11 +1818,11 @@ class Post extends Base
             $link_attr->href,
             $link_text,
             array(
-                'title' => $link_attr->title,
+                'title'  => $link_attr->title,
                 'target' => $link_attr->target,
-                'class' => $classes,
-                'id' => $id,
-                'style' => $styles
+                'class'  => $classes,
+                'id'     => $id,
+                'style'  => $styles
             )
         );
     }

--- a/src/Post.php
+++ b/src/Post.php
@@ -1742,4 +1742,114 @@ class Post extends Base
         $instance->load($post_id, $load_terms);
         return $instance;
     }
+
+
+    /**
+     * Decode an encoded string into a link object
+     * @param string $encoded
+     * @return array
+     */
+    public static function decodeLinkObject($encoded)
+    {
+        return json_decode(urldecode($encoded));
+    }
+
+
+    /**
+     * Get just the URL from a field type of link
+     * @param string $field
+     * @return string
+     */
+    public function getLinkURL($field)
+    {
+        $link_attr = self::decodeLinkObject($this->get($field));
+        return $link_attr->href;
+    }
+
+
+    /**
+     * Get a field from a link object (href | title | target)
+     * @param string $field
+     * @param string $part
+     * @return string
+     */
+    public function getLinkPart($field, $part)
+    {
+        $link_attr = self::decodeLinkObject($this->get($field));
+        return $link_attr->$part;
+    }
+
+
+    /**
+     * Get an HTML link from attributes that come from a link object
+     * This is mainly used with the field type of link
+     * @param object $link_attr
+     * @param string $body
+     * @param string $classes
+     * @param string $id
+     * @param string $styles
+     * @return string
+     */
+    public function linkAttribsToHTMLString($link_attr, $body='', $classes='', $id='', $styles='')
+    {
+        $link_text = null;
+        if(strlen($link_attr->title)) {
+            $link_text = $link_attr->title;
+        } elseif(strlen($body)) {
+            $link_text = $body;
+        } else {
+            $link_text = $link_attr->href;
+        }
+        return Html::link(
+            $link_attr->href,
+            $link_text,
+            array(
+                'title' => $link_attr->title,
+                'target' => $link_attr->target,
+                'class' => $classes,
+                'id' => $id,
+                'style' => $styles
+            )
+        );
+    }
+
+
+    /**
+     * Get a field from a link object (href | title | target)
+     * @param string $field
+     * @param string $part
+     * @return string
+     */
+    public function getLinkHTML($field, $body='', $classes='', $id='', $styles='')
+    {
+        $link_attr = self::decodeLinkObject($this->get($field));
+        return self::linkAttribsToHTMLString(
+            $link_attr,
+            $body,
+            $classes,
+            $id,
+            $styles
+        );
+    }
+
+
+    /**
+     * Get an HTML link from an encoded link object
+     * @param string $oject_string
+     * @param string $body
+     * @param string $classes
+     * @param string $id
+     * @param string $styles
+     * @return string
+     */
+    public static function getLinkHTMLFromObject($object_string, $body='', $classes='', $id='', $styles='')
+    {
+        return self::linkAttribsToHTMLString(
+            self::decodeLinkObject($object_string),
+            $body,
+            $classes,
+            $id,
+            $styles
+        );
+    }
 }

--- a/src/Post.php
+++ b/src/Post.php
@@ -136,7 +136,9 @@ class Post extends Base
         $post = array();
         $meta = array();
         $post_fields = static::getCoreFieldKeys();
-        $meta_fields = $this->getMetaFieldKeys();
+        $fields_and_attribs = static::getFields();
+        $meta_fields = array_keys($fields_and_attribs);
+
         foreach ($this->_info as $k => $v) {
             if (in_array($k, $post_fields)) $post[$k] = $v;
             elseif (in_array($k, $meta_fields)) $meta[$k] = $v;
@@ -186,6 +188,9 @@ class Post extends Base
         // save meta
         if (count($meta) > 0) {
             foreach ($meta as $k => $v) {
+                if (preg_match('/link/', $fields_and_attribs[$k]['type'])) {
+                    $v = urldecode($v);
+                }
                 if ($is_update) update_post_meta($this->_info[self::ID], $k, $v);
                 else add_post_meta($this->_info[self::ID], $k, $v);
             }

--- a/tests/PostHTMLTest.php
+++ b/tests/PostHTMLTest.php
@@ -70,6 +70,7 @@ class PostHTMLTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $metabox->find('input[type=text][name=photo_path]')->val());
         $this->assertEquals('', $metabox->find('input[type=text][name=resume_pdf_path]')->val());
         $this->assertEquals('', $metabox->find('input[type=url][name=website_url]')->val());
+        $this->assertEquals('', $metabox->find('input[type=link][name=website_link]')->val());
 
         // Taxonomies
         $this->assertEquals(1, $doc->find('#taxonomy-irs')->length);
@@ -119,6 +120,7 @@ class PostHTMLTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $metabox->find('input[type=text][name=photo_path]')->val());
         $this->assertEquals('', $metabox->find('input[type=text][name=resume_pdf_path]')->val());
         $this->assertEquals('', $metabox->find('input[type=url][name=website_url]')->val());
+        $this->assertEquals('', $metabox->find('input[type=link][name=website_link]')->val());
 
         // Taxonomies
         $this->assertEquals(1, $doc->find('#taxonomy-irs')->length);
@@ -136,6 +138,7 @@ class PostHTMLTest extends PHPUnit_Framework_TestCase
         $person->photo_path = '/wp-content/uploads/sample.jpg';
         $person->resume_pdf_path = '/wp-content/uploads/sample.pdf';
         $person->website_url = 'https://google.com/';
+        $person->website_link = '{"href":"https://www.google.com","title":"Hello world!","target":"_blank"}';
         $person->save();
 
         // Get HTML again
@@ -162,6 +165,7 @@ class PostHTMLTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('/wp-content/uploads/sample.jpg', $metabox->find('input[type=text][name=photo_path]')->val());
         $this->assertEquals('/wp-content/uploads/sample.pdf', $metabox->find('input[type=text][name=resume_pdf_path]')->val());
         $this->assertEquals('https://google.com/', $metabox->find('input[type=url][name=website_url]')->val());
+        $this->assertEquals('https://www.google.com', json_decode($metabox->find('input[type=link][name=website_link]')->val())->href);
 
         // Update person with terms
         $person->setTerms(array('term1'), 'irs');

--- a/tests/wp-content/plugins/taco_person/taco_person.php
+++ b/tests/wp-content/plugins/taco_person/taco_person.php
@@ -41,6 +41,7 @@ class Person extends \Taco\Post
             'photo_path'      =>array('type'=>'image'),
             'resume_pdf_path' =>array('type'=>'file'),
             'website_url'     =>array('type'=>'url'),
+            'website_link'    =>array('type'=>'link'),
         );
     }
 


### PR DESCRIPTION
Brian, Alan, and whoever else wishes to view this request. This branch I'm requesting to merge with master allows for a field type called link. An example in getFields would be something like this:

'test_link' => array('type' => 'link')

The "type link" tells JavaScript to create an interface (See screenshot) for selecting the url, body and target. This information is then stored in a JSON object.

![screen shot 2015-07-04 at 12 33 33 am](https://cloud.githubusercontent.com/assets/1744041/8506802/53aaa024-21e4-11e5-975f-d165aaef5bea.png)

At the template level, I've included a number of different methods for rendering out these links.
Here is an example of a most commonly used method (used in a prior project)  "echo $post->getLinkHTML('field_name')".

I had to modify the save method of Post.php slightly. I'm having to check if a field is of type "link", and if so convert the value in way that it can be saved in the database without error. In order to do this, I had to load getFields at the beginning of the save method. My concern with doing this, is performance. I did test and compare, and the difference was nominal.

Please let me know what you think, and if you have any suggestions. There is a big use case for the link field. 



