### PR TITLE
add fallback WYSIWYG for when there is none

### DIFF
--- a/src/Frontend/assets/css/fields.css
+++ b/src/Frontend/assets/css/fields.css
@@ -16,3 +16,4 @@ img.thumbnail { max-width: 100px; max-height: 100px; }
 }
 .mceIframeContainer { background: #fff; }
 .inside table { width: 100%; }
+#temp-editor { display: none; }


### PR DESCRIPTION
When there are no fields with 'class' => 'WYSIWYG' and getSupports() does not have 'editor' in the array, functionality for custom fields like "image", "file", and the newly added link field do not work. The code that was implemented here basically checks if there are any WYSIWYG fields, and if not, add it to admin page, and then hide it with css. Yes this does seem like a hack. I could have loaded the scripts by hard coding them in manually, but the problem with that is when WordPress updates, it could break. The PHP code in this script, and TacoWordPress core utilizes a function called "wp_editor()", which is responsible for rendering this field and generating its respective JavaScript. This assures us that anytime we call this, it should work as expected. That is all.