### PR TITLE
Bugfix in sorting list by taxonomy column.

### DIFF
--- a/src/Post.php
+++ b/src/Post.php
@@ -759,7 +759,10 @@ class Post extends Base
         // but WordPress will think we're sorting by a meta_key.
         // Correct for this bad assumption by WordPress.
         $clauses['where'] = str_replace(
-            "AND ({$wpdb->postmeta}.meta_key = '".$taxonomy."' )",
+            array(
+                "AND ({$wpdb->postmeta}.meta_key = '".$taxonomy."' )",
+                "AND ( \n  {$wpdb->postmeta}.meta_key = '".$taxonomy."'\n)"
+            ),
             '',
             $clauses['where']
         );


### PR DESCRIPTION
This would fix the issue in sorting by taxonomy when WP generated `where` clause looks like below:

```
WHERE 1=1  
AND ( 
  wp_postmeta.meta_key = 'priority'
) AND wp_posts.post_type = 'task'
...
```