### PR TITLE
Transliterate accented characters and remove apostrophes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "https://tacowordpress.github.io/tacowordpress/",
   "keywords": ["wordpress", "custom post type", "custom terms", "taco", "tacowordpress"],
   "minimum-stability": "dev",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "require": {
     "php": ">=5.3.0"
   },

--- a/src/Util/Str.php
+++ b/src/Util/Str.php
@@ -89,11 +89,73 @@ class Str
      */
     public static function machine($str, $separator = '_')
     {
+        $accented = [
+            '/[áăâäàāąåãǻǎ]/u',
+            '/[æǽ]/u',
+            '/[ćčçĉċ]/u',
+            '/[ðďđ]/u',
+            '/[éĕěêëėèēę]/u',
+            '/[ğĝģġ]/u',
+            '/[ħĥ]/u',
+            '/[ıíĭîïìīįĩǐ]/u',
+            '/[ĳ]/u',
+            '/[ȷĵ]/u',
+            '/[ķ]/u',
+            '/[ĺľļŀł]/u',
+            '/[ńňņñŉ]/u',
+            '/[ŋ]/u',
+            '/[óŏôöòőōøõǿǒơ]/u',
+            '/[œ]/u',
+            '/[ŕřŗ]/u',
+            '/[śšşŝș]/u',
+            '/[ß]/u',
+            '/[ŧťţț]/u',
+            '/[þ]/u',
+            '/[úŭûüùűūųůũǔǖǘǚǜư]/u',
+            '/[ẃŵẅẁ]/u',
+            '/[ýŷÿỳ]/u',
+            '/[źžż]/u',
+        ];
+        $non_accented = [
+            'a',
+            'ae',
+            'c',
+            'd',
+            'e',
+            'g',
+            'h',
+            'i',
+            'ij',
+            'j',
+            'k',
+            'l',
+            'n',
+            'ng',
+            'o',
+            'oe',
+            'r',
+            's',
+            'ss',
+            't',
+            'th',
+            'u',
+            'w',
+            'y',
+            'z',
+        ];
+        
         $out = strtolower($str);
-        $out = preg_replace('/[^a-z0-9' . $separator . ']/', $separator, $out);
-        $out = preg_replace('/[' . $separator . ']{2,}/', $separator, $out);
-        $out = preg_replace('/^' . $separator . '/', '', $out);
-        $out = preg_replace('/' . $separator . '$/', '', $out);
+        foreach ($accented as $value) {
+            $out = preg_replace($accented, $non_accented, $out);
+        }
+        $out = preg_replace(
+            array('/[\'’]/', '/[^a-zA-Z0-9\s_]/', '/[\s_]+/', '/^_|_$/'),
+            array('', '_', '_', ''),
+            $out
+        );
+        if ($separator !== '_') {
+            $out = str_replace('_', $separator, $out);
+        }
         return $out;
     }
 


### PR DESCRIPTION
This change allows `Str::machine()` to preserve accented characters in their non-accented forms, and improves handling of apostrophes.

Example:
- Input string: `These can't be þe drönes you’re looking for, can they??`
- Previous output: `these-can-t-be-e-dr-nes-you-re-looking-for-can-they`
- Improved output: `these-cant-be-the-drones-youre-looking-for-can-they`

**Note:** This is potentially a breaking change. If `Str::machine()` is implemented in a case where the resulting machine string is expected to be the same every time — such as in the case of finding an existing record by the machine value of a string — the changes represented here may cause said functionality to fail.