### PR TITLE
Remove invalid attributes from fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "https://tacowordpress.github.io/tacowordpress/",
   "keywords": ["wordpress", "custom post type", "custom terms", "taco", "tacowordpress"],
   "minimum-stability": "dev",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "require": {
     "php": ">=5.3.0",
     "tacowordpress/util": ">=0.1.1"

--- a/src/Base.php
+++ b/src/Base.php
@@ -441,9 +441,6 @@ class Base
         if (array_key_exists('required', $field)) {
             $field['required'] = 'required';
         }
-        if (array_key_exists('label', $field)) {
-            unset($field['label']);
-        }
         if (!array_key_exists('id', $field)) {
             $field['id'] = $name;
         }
@@ -455,7 +452,7 @@ class Base
 
             $htmls[] = '<div class="upload_field">';
             $htmls[] = '<div class="upload-field-container">';
-            $htmls[] = Html::tag('input', null, array_merge($field, array('type'=>'text')));
+            $htmls[] = Html::tag('input', null, array_merge(self::scrubAttributes($field), array('type'=>'text')));
             $htmls[] = Html::tag('input', null, array('type'=>'button', 'value'=>'Select file', 'class'=>'browse'));
             $htmls[] = Html::tag('input', null, array('type'=>'button', 'value'=>'Clear', 'class'=>'clear'));
             $htmls[] = '</div>';
@@ -472,7 +469,7 @@ class Base
                 return ob_get_clean();
             }
             unset($field['type']);
-            return sprintf('<textarea%s>%s</textarea>', Html::attribs($field), $field['value']);
+            return sprintf('<textarea%s>%s</textarea>', Html::attribs(self::scrubAttributes($field)), $field['value']);
         }
         if (in_array($type, array('checkbox', 'radio'))) {
             if (in_array($field['value'], array(1, 'on'))) {
@@ -481,7 +478,7 @@ class Base
             }
 
             $field['value'] = 1; // value attrib should be 1 so that $_POST[$name]=1 (or doesn't exist)
-            return Html::tag('input', null, $field);
+            return Html::tag('input', null, self::scrubAttributes($field));
         }
         if ($type === 'select') {
             if (!array_key_exists('', $field['options'])) {
@@ -495,7 +492,7 @@ class Base
                 $field['options'] = $options;
             }
 
-            return Html::selecty($field['options'], $field['value'], $field);
+            return Html::selecty($field['options'], $field['value'], self::scrubAttributes($field));
         }
 
         // Default to text field
@@ -505,7 +502,29 @@ class Base
         }
 
         // Render remaining fields with types normally assigned by type attrib (text, email, search, password)
-        return Html::tag('input', null, $field);
+        return Html::tag('input', null, self::scrubAttributes($field));
+    }
+
+
+    /**
+     * Remove invalid HTML attribute keys from field definition
+     * @param array $field
+     * @return array
+     */
+    private static function scrubAttributes($field)
+    {
+        $invalid_keys = [
+            'default',
+            'description',
+            'label',
+            'options',
+        ];
+        foreach ($invalid_keys as $invalid_key) {
+            if (array_key_exists($invalid_key, $field)) {
+                unset($field[$invalid_key]);
+            }
+        }
+        return $field;
     }
 
 


### PR DESCRIPTION
This removes a small set of attributes from HTML fields in the admin. These particular attributes are the ones most likely to be used when defining fields, and they're hard-coded for brevity, since `input` elements accept a [large number of attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input).

In the case of WYSIWYG fields, most keys in the field definition don't survive the trip to the rendered HTML, so it's not necessary to unset them.