### PR TITLE
Improve support for namespaced post and term classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "homepage": "https://tacowordpress.github.io/tacowordpress/",
   "keywords": ["wordpress", "custom post type", "custom terms", "taco", "tacowordpress"],
   "minimum-stability": "dev",
-  "version": "0.7.4",
+  "version": "0.7.6",
   "require": {
     "php": ">=5.3.0",
     "tacowordpress/util": ">=0.1.1"

--- a/src/Base.php
+++ b/src/Base.php
@@ -680,13 +680,25 @@ class Base
 
 
     /**
+     * Get humanized class name
+     * @return string
+     */
+    public function getHumanClass()
+    {
+        $called_class_segments = explode('\\', get_called_class());
+        $class_name = end($called_class_segments);
+        return Str::convert($class_name, 'camel', 'human');
+    }
+
+
+    /**
      * Get the singular name
      * @return string
      */
     public function getSingular()
     {
         return (is_null($this->singular))
-            ? Str::camelToHuman(get_called_class())
+            ? static::getHumanClass()
             : $this->singular;
     }
 

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -1,0 +1,49 @@
+<?php
+namespace Taco;
+
+use Taco\Util\Str as Str;
+
+class BaseFactory
+{
+    
+    /**
+     * Resolve class name
+     * @param string $identifier
+     * @return string
+     */
+    public static function resolveClassName($identifier)
+    {
+        $class = Str::pascal($identifier);
+        
+        if (class_exists($class)) {
+            return $class;
+        }
+        
+        // Check if class belongs to pre-defined namespace
+        $namespace = (strpos(get_called_class(), 'Taco\Post') === 0)
+            ? 'POST_NAMESPACE'
+            : 'TERM_NAMESPACE';
+        if (defined($namespace) && class_exists(constant($namespace).'\\'.$class)) {
+            return constant($namespace).'\\'.$class;
+        }
+        
+        // Check if any subclass has a matching class name (this only works if
+        // every class name is unique, regardless of namespace)
+        $subclasses = BaseLoader::getSubclasses();
+        foreach ($subclasses as $subclass) {
+            if (preg_match('/\b'.$class.'$/', $subclass)) {
+                return $subclass;
+            }
+        }
+        
+        // Check if identifier represents the full namespace (this only works if
+        // each segment of the fully-qualified class name is a single word)
+        $namespaced_class = join('\\', array_map('ucfirst', explode(Base::SEPARATOR, $identifier)));
+        if (class_exists($namespaced_class)) {
+            return $namespaced_class;
+        }
+        
+        return null;
+    }
+    
+}

--- a/src/BaseFactory.php
+++ b/src/BaseFactory.php
@@ -6,12 +6,32 @@ use Taco\Util\Str as Str;
 class BaseFactory
 {
     
+    private static $class_pairs = null;
+    
+    
     /**
      * Resolve class name
      * @param string $identifier
      * @return string
      */
     public static function resolveClassName($identifier)
+    {
+        if (is_array(self::$class_pairs) && array_key_exists($identifier, self::$class_pairs)) {
+            return self::$class_pairs[$identifier];
+        }
+        
+        $class_name = self::inferClassName($identifier);
+        self::$class_pairs[$identifier] = $class_name;
+        return $class_name;
+    }
+    
+    
+    /**
+     * Infer class name
+     * @param string $identifier
+     * @return string
+     */
+    private static function inferClassName($identifier)
     {
         $class = Str::pascal($identifier);
         

--- a/src/BaseLoader.php
+++ b/src/BaseLoader.php
@@ -1,0 +1,29 @@
+<?php
+namespace Taco;
+
+class BaseLoader
+{
+    
+    /**
+     * Get all subclasses
+     * @return array
+     */
+    public static function getSubclasses()
+    {
+        $subclasses = array();
+        $parent_class = (strpos(get_called_class(), 'Taco\Post') === 0)
+            ? 'Taco\Post'
+            : 'Taco\Term';
+        
+        foreach (get_declared_classes() as $class) {
+            if (method_exists($class, 'isLoadable') && $class::isLoadable() === false) {
+                continue;
+            }
+            if (is_subclass_of($class, $parent_class)) {
+                $subclasses[] = $class;
+            }
+        }
+        return $subclasses;
+    }
+    
+}

--- a/src/Post.php
+++ b/src/Post.php
@@ -948,10 +948,8 @@ class Post extends Base
      */
     public function getPostType()
     {
-        $called_class_segments = explode('\\', get_called_class());
-        $class_name = end($called_class_segments);
         return (is_null($this->post_type))
-            ? Str::machine(Str::camelToHuman($class_name), Base::SEPARATOR)
+            ? Str::machine(static::getHumanClass(), Base::SEPARATOR)
             : $this->post_type;
     }
 

--- a/src/Post/Factory.php
+++ b/src/Post/Factory.php
@@ -13,15 +13,15 @@ use Taco\Util\Str as Str;
 
 /**
  * Custom post factory
- * Generates instances of classes extending CustomPostType
+ * Generates instances of classes extending \Taco\Post
  */
-class Factory
+class Factory extends \Taco\BaseFactory
 {
     
     /**
      * Create an instance based on a WP post
      * This basically autoloads the meta data
-     * @param object $post
+     * @param int/string/object $post
      * @param bool $load_terms
      * @return object
      */
@@ -37,13 +37,18 @@ class Factory
             $post = get_post($post);
         }
         if (!is_object($post)) {
-            throw new \Exception(sprintf('Post %s not found in the database', json_encode($original_post)));
+            throw new \Exception(sprintf(
+                'Post %s not found in the database',
+                json_encode($original_post)
+            ));
         }
         
-        // TODO Refactor how this works to be more explicit and less guess
-        $class = str_replace(' ', '', ucwords(str_replace(Base::SEPARATOR, ' ', $post->post_type)));
-        if (!class_exists($class)) {
-            $class = str_replace(' ', '\\', ucwords(str_replace(Base::SEPARATOR, ' ', $post->post_type)));
+        $class = self::resolveClassName($post->post_type);
+        if (!is_string($class)) {
+            throw new \Exception(sprintf(
+                'Post class %s does not exist',
+                Str::pascal($post->post_type)
+            ));
         }
         
         $instance = new $class;
@@ -75,4 +80,5 @@ class Factory
         }
         return $out;
     }
+    
 }

--- a/src/Post/Loader.php
+++ b/src/Post/Loader.php
@@ -20,7 +20,7 @@ use Taco\Util\Str as Str;
 global $taxonomies_infos;
 $taxonomies_infos = array();
 
-class Loader
+class Loader extends \Taco\BaseLoader
 {
         
     /**
@@ -143,22 +143,4 @@ class Loader
         return $count;
     }
     
-    
-    /**
-     * Get all subclasses
-     * @return array
-     */
-    public static function getSubclasses()
-    {
-        $subclasses = array();
-        foreach (get_declared_classes() as $class) {
-            if (method_exists($class, 'isLoadable') && $class::isLoadable() === false) {
-                continue;
-            }
-            if (is_subclass_of($class, 'Taco\Post')) {
-                $subclasses[] = $class;
-            }
-        }
-        return $subclasses;
-    }
 }

--- a/src/Term.php
+++ b/src/Term.php
@@ -43,10 +43,8 @@ class Term extends Base
      */
     public function getTaxonomyKey()
     {
-        $called_class_segments = explode('\\', get_called_class());
-        $class_name = end($called_class_segments);
         return (is_null($this->taxonomy_key))
-            ? Str::machine(Str::camelToHuman($class_name), Base::SEPARATOR)
+            ? Str::machine(static::getHumanClass(), Base::SEPARATOR)
             : $this->taxonomy_key;
     }
 

--- a/src/Term/Factory.php
+++ b/src/Term/Factory.php
@@ -15,7 +15,7 @@ use Taco\Util\Str as Str;
  * Taco term factory
  * Generates instances of classes extending \Taco\Term
  */
-class Factory
+class Factory extends \Taco\BaseFactory
 {
     
     /**
@@ -36,12 +36,14 @@ class Factory
             $term = get_term($term, $taxonomy);
         }
         
-        // TODO Refactor how this works to be more explicit and less guess
-        $class = str_replace(' ', '', ucwords(str_replace(Base::SEPARATOR, ' ', $term->taxonomy)));
-        if (!class_exists($class)) {
-            $class = str_replace(' ', '\\', ucwords(str_replace(Base::SEPARATOR, ' ', $term->taxonomy)));
+        $class = self::resolveClassName($term->taxonomy);
+        if (!is_string($class)) {
+            throw new \Exception(sprintf(
+                'Term class %s does not exist',
+                Str::pascal($term->taxonomy)
+            ));
         }
-
+        
         $instance = new $class;
         $instance->load($term->term_id);
         return $instance;
@@ -68,4 +70,5 @@ class Factory
         }
         return $out;
     }
+    
 }

--- a/src/Term/Loader.php
+++ b/src/Term/Loader.php
@@ -13,7 +13,7 @@ use Taco\Util\Str as Str;
  * Utility functions for loading the taco taxonomies
  */
 
-class Loader
+class Loader extends \Taco\BaseLoader
 {
 
     /**
@@ -53,23 +53,4 @@ class Loader
         }
     }
 
-
-    /**
-     * Get all subclasses
-     * @return array
-     */
-    public static function getSubclasses()
-    {
-        $subclasses = array();
-        foreach (get_declared_classes() as $class) {
-            if (method_exists($class, 'isLoadable') && $class::isLoadable() === false) {
-                continue;
-            }
-
-            if (is_subclass_of($class, 'Taco\Term')) {
-                $subclasses[] = $class;
-            }
-        }
-        return $subclasses;
-    }
 }


### PR DESCRIPTION
Starting with a standard WordPress object, we can only infer the corresponding Taco class name from the post type or taxonomy key. This aims to improve namespacing support by trying a few methods of inferring the class name before failing.

The most explicit way of making sure this works is by looking for two new constants: `POST_NAMESPACE` and `TERM_NAMESPACE`. These could be defined in the config, and would point the factory method to the right place.

This still requires a good amount of testing. I have not yet tested class names containing acronyms, such as `ABCPost` or `PostABC`. Class names like these might require overriding `getPostType()` and `getTaxonomyKey()`, since their resulting slugs may not be obvious.